### PR TITLE
ISSUE #10 and #37 - Add agentAddress configuration and remove static snmpd.conf 

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ these following attributes to best suit your own environment.
 * `snmp['conf_mode']`
   - SNMP configuration file mode, default is 0600.
 
-* `snmp['conf_user']`
+* `snmp['conf_owner']`
   - SNMP configuration file owner, default is 'root'.
 
 * `snmp['conf_group']`

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Notable overridable attributes are as follows.  It is recommended to override
 these following attributes to best suit your own environment.
 
 * `snmp['agentAddress']`
-  - SNMP Listening address, default is UDP port 161 on all interfaces. See `man 8 snmpd`,
+  - SNMP Listening address, default is "udp:161". See `man 8 snmpd`,
     section LISTENING ADDRESSES for further details.
 
 * `snmp['community']`

--- a/README.md
+++ b/README.md
@@ -24,6 +24,18 @@ manufactured hardware is detected by Ohai.
 Notable overridable attributes are as follows.  It is recommended to override
 these following attributes to best suit your own environment.
 
+* `snmp['conffile']`
+  - SNMP configuration location, default is "/etc/snmp/snmpd.conf". 
+
+* `snmp['conf_mode']`
+  - SNMP configuration file mode, default is 0600.
+
+* `snmp['conf_user']`
+  - SNMP configuration file owner, default is 'root'.
+
+* `snmp['conf_group']`
+  - SNMP configuration file group, default is 'root'.
+
 * `snmp['agentAddress']`
   - SNMP Listening address, default is "udp:161". See `man 8 snmpd`,
     section LISTENING ADDRESSES for further details.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ manufactured hardware is detected by Ohai.
 Notable overridable attributes are as follows.  It is recommended to override
 these following attributes to best suit your own environment.
 
+* `snmp['agentAddress']`
+  - SNMP Listening address, default is UDP port 161 on all interfaces. See `man 8 snmpd`,
+    section LISTENING ADDRESSES for further details.
+
 * `snmp['community']`
   - SNMP Community String, default is "public".
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -32,6 +32,7 @@ end
 # redhat, centos, fedora, scientific, debian, ubuntu
 default['snmp']['service'] = 'snmpd'
 
+default['snmp']['agentAddress'] = 'udp:161'
 default['snmp']['community'] = 'public'
 default['snmp']['sec_name'] = { 'notConfigUser' => %w(default) }
 default['snmp']['sec_name6'] = { 'notConfigUser' => %w(default) }

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -32,6 +32,10 @@ end
 # redhat, centos, fedora, scientific, debian, ubuntu
 default['snmp']['service'] = 'snmpd'
 
+default['snmp']['conffile'] = '/etc/snmp/snmpd.conf'
+default['snmp']['conf_owner'] = 'root'
+default['snmp']['conf_group'] = 'root'
+default['snmp']['conf_mode'] = 0600
 default['snmp']['agentAddress'] = 'udp:161'
 default['snmp']['community'] = 'public'
 default['snmp']['sec_name'] = { 'notConfigUser' => %w(default) }

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ license 'Apache 2.0'
 description 'Installs/Configures snmp on redhat, centos, ubuntu, debian'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 name 'snmp'
-version '4.0.0'
+version '4.0.1'
 
 recipe 'snmp', 'Installs and configures snmpd'
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -39,7 +39,7 @@ groupnames = groupnames.uniq
 
 template node['snmp']['conffile'] do
   source 'snmpd.conf.erb'
-  mode node['snmp'][['conf_mode']
+  mode node['snmp']['conf_mode']
   owner node['snmp']['conf_owner']
   group node['snmp']['conf_group']
   variables(groups: groupnames)

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -37,10 +37,11 @@ node['snmp']['groups']['v1'].each_key { |key| groupnames << key }
 node['snmp']['groups']['v2c'].each_key { |key| groupnames << key }
 groupnames = groupnames.uniq
 
-template '/etc/snmp/snmpd.conf' do
-  mode 00600
-  owner 'root'
-  group 'root'
+template node['snmp']['conffile'] do
+  source 'snmpd.conf.erb'
+  mode node['snmp'][['conf_mode']
+  owner node['snmp']['conf_owner']
+  group node['snmp']['conf_group']
   variables(groups: groupnames)
   notifies :restart, "service[#{node['snmp']['service']}]"
 end

--- a/templates/default/snmpd.conf.erb
+++ b/templates/default/snmpd.conf.erb
@@ -8,7 +8,7 @@
 ###############################################################################
 #
 
-agentAddress udp:161<% if node.key?('ip6address') -%>,udp6:161<% end -%>
+agentAddress <%= node['snmp']['agentAddress'] %><% if node.key?('ip6address') -%>,udp6:161<% end -%>
 
 ###############################################################################
 # Access Control


### PR DESCRIPTION
Moves agentAddress from static to an attribute.  Allows binding snmpd to individual interfaces/non-standard transports/ports.   Note -  this does not handle the IPV6 side, only IPV4.